### PR TITLE
feat: add 404 page and update package.json for prev pr

### DIFF
--- a/packages/example/src/pages/404.tsx
+++ b/packages/example/src/pages/404.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { Link } from "gatsby"
+
+export default () => {
+  return (
+    <div className="w-full py-20 px-8 lg:px-16 xl:px-24 lg:w-2/3">
+      <h1 className="text-3xl font-extrabold leading-tight lg:text-5xl">
+        Error 404
+      </h1>
+      <h3 className="text-lg font-medium lg:text-xl">
+        The page you're looking for doesn't exist.
+        <br />
+        <br />
+        <Link to="/" className="text-link">
+          Go back to homepage
+        </Link>
+      </h3>
+    </div>
+  )
+}

--- a/packages/gatsby-theme-project-portal/package.json
+++ b/packages/gatsby-theme-project-portal/package.json
@@ -13,11 +13,11 @@
     "gatsby-plugin-postcss": "^5.1.0",
     "gatsby-source-filesystem": "^4.1.0",
     "markdown-to-jsx": "^7.1.7",
+    "moment": "^2.29.4",
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
-    "moment": "^2.29.4",
     "react-icons": "^4.4.0",
     "react-share": "^4.4.0"
   },


### PR DESCRIPTION
Including 404 page, but 404 Page is currently revised by removing Layout component. Layout component will be added back in after relevant components are added in first.

404 page needs to be added in to address error discovered when running `gatsby build`, which requires custom 404 page. 