### PR TITLE
feat: add additional part to the packfile name so it's unique each time

### DIFF
--- a/test-packaging.sh
+++ b/test-packaging.sh
@@ -133,7 +133,7 @@ package-and-install () {
       pack) {
         # Get the path where the pack-file will be created
         mkdir -p "$artifactDir"
-        packPath="$artifactDir/theme-$(date '+%s')-$(git rev-parse --short HEAD).tgz"
+        packPath="$artifactDir/theme-$(date '+%s')-$(git rev-parse --short HEAD)-$(base64 < "/dev/urandom" | tr -dc '0-9a-zA-Z' | head -c3 ).tgz"
         export packPath
 
         # Create the pack file itself


### PR DESCRIPTION
The packaging-test script generates a deterministic name for the pack-file, but if run several times concurrently, might lead to the file being overwritten whilst it's being used. I'm not sure if this is a real problem, but there's an easy fix nevertheless.

In this PR, we add an extra random component to the end of the pack file name:
`theme-{UNIX epoch}-{commit hash}-{three random letters}.tgz`
... so that each instance of the script generates an independent pack file.

The probability that two of the names will collide is ≈ 3/140,608, so it's unlikely that this will happen in the lifetime of the project.