### PR TITLE
feat: add netlify previews for projects

### DIFF
--- a/.idea/project-portal-theme.iml
+++ b/.idea/project-portal-theme.iml
@@ -17,6 +17,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/example-site/public" />
       <excludeFolder url="file://$MODULE_DIR$/packages/nc-content/.cache" />
       <excludeFolder url="file://$MODULE_DIR$/packages/nc-content/public" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/example-site/.cache" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
Add initial previews for projects and contacts.

⚠️ Doesn't include contact data directly – just the contact name. 

**Why is this so complicated? Why did you modify the Contact?** This PR requires some refactoring of the Contact and ProjectDetail to remove the Gatsby-specific components (like GatsbyImage and StaticImage, StaticQuery, and any hooks which rely on the static query, like the useStaticText or useProjectPortalConfig) and allow using the components without these. Otherwise, the preview fails to render, as in Netlify the Static query results aren't available.

<img width="1192" alt="Screen Shot 2022-10-27 at 17 49 56" src="https://user-images.githubusercontent.com/2803227/198405298-d8a35e11-03cf-4458-bd63-f5eb96d3e670.png">

<img width="994" alt="Screen Shot 2022-10-27 at 17 53 51" src="https://user-images.githubusercontent.com/2803227/198405456-9c9d7a7a-591b-4594-833f-0845a261cb37.png">


