### PR TITLE
Refactor project detail layout

### DIFF
--- a/packages/gatsby-theme-project-portal/src/components/ProjectDetail.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/ProjectDetail.tsx
@@ -1,7 +1,5 @@
-import { Link, withPrefix } from "gatsby"
 import React, { FunctionComponent } from "react"
 import moment from "moment"
-import { BackIcon } from "./BackIcon"
 
 import {
   ContactType,
@@ -9,9 +7,10 @@ import {
   MainContact,
   SectionOfItem,
   ShareProject,
-} from "./index"
+  CollaboratorDetails,
+  ProjectTeam,
+} from "."
 
-import { CollaboratorDetails, ProjectTeam } from "./index"
 import { statusOutput, isNA, isEmpty } from "../utils"
 
 export interface ProjectDetailLayoutProps {
@@ -192,14 +191,6 @@ export const ProjectDetailLayout: FunctionComponent<
             <ProjectTeam title="Project Team" contacts={projectTeam} />
           )
         )}
-        <section className="my-12">
-          <Link to={withPrefix(`/${status === "open" ? "" : status}`)}>
-            <button className="btn m-responsive">
-              <BackIcon />
-              <span className="pl-2">Back</span>
-            </button>
-          </Link>
-        </section>
       </div>
     </article>
   )

--- a/packages/gatsby-theme-project-portal/src/layouts/ProjectDetailPage.tsx
+++ b/packages/gatsby-theme-project-portal/src/layouts/ProjectDetailPage.tsx
@@ -1,6 +1,11 @@
 import { Layout } from "./Layout"
-import { ProjectDetailLayout, ProjectDetailLayoutProps } from "../components"
+import {
+  BackIcon,
+  ProjectDetailLayout,
+  ProjectDetailLayoutProps,
+} from "../components"
 import React, { FunctionComponent } from "react"
+import { Link, withPrefix } from "gatsby"
 
 // For the ProjectDetailPage we add the slug which isn't on the layout
 interface ProjectDetailPageProps extends ProjectDetailLayoutProps {
@@ -27,6 +32,20 @@ export const ProjectDetailPage: FunctionComponent<
       <main>
         <ProjectDetailLayout {...project} />
       </main>
+      <div className="p-responsive pb-4">
+        <section className="my-12">
+          <Link
+            to={withPrefix(
+              `/${project.status === "open" ? "" : project.status}`
+            )}
+          >
+            <button className="btn m-responsive">
+              <BackIcon />
+              <span className="pl-2">Back</span>
+            </button>
+          </Link>
+        </section>
+      </div>
     </Layout>
   )
 }


### PR DESCRIPTION
- Update to match legacy formatting
- refactor to make "projectDetail" article completely independent of the layout (back-button)