### PR TITLE
fix: reset branch name in config.yml for netlify cms

### DIFF
--- a/packages/example-site/static/admin/config.yml
+++ b/packages/example-site/static/admin/config.yml
@@ -1,4 +1,4 @@
 backend:
   name: git-gateway
-  branch: 228-add-editorial-workflow
+  branch: main
 local_backend: false


### PR DESCRIPTION
reset branch name for backend (from #228)