### PR TITLE
fix: remove unnecessary variable initializer

### DIFF
--- a/packages/gatsby-theme-project-portal/src/components/ProjectPage.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/ProjectPage.tsx
@@ -8,7 +8,7 @@ import { isNA } from "../utils"
 
 function customSort(dateField: string, sortAscending: boolean) {
   return function (a, b) {
-    let sortValue = 0
+    let sortValue
     const aValue = a[dateField]
     const bValue = b[dateField]
 


### PR DESCRIPTION
will always be set by the "if" below