### PR TITLE
fix: footer link styling

### DIFF
--- a/packages/gatsby-theme-project-portal/src/components/Footer.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/Footer.tsx
@@ -64,7 +64,7 @@ export const FooterLayout: FunctionComponent<FooterProps> = ({
 
 const ListItem = ({ target, children }) => {
   return (
-    <li className="block px-2 py-2 lg:inline-block lg:ml-6 underline hover:no-underline text-center">
+    <li className="block px-2 py-2 lg:inline-block lg:mx-3 underline hover:no-underline text-center">
       <a href={target}>{children}</a>
     </li>
   )


### PR DESCRIPTION
Fixes:
Old:
<img width="975" alt="Screenshot 2023-07-31 at 08 53 13" src="https://github.com/thepolicylab-projectportals/project-portal-theme/assets/2803227/19b759f5-84f2-4337-bfa2-60d078d8e0e7">

New: 
<img width="968" alt="Screenshot 2023-07-31 at 08 52 25" src="https://github.com/thepolicylab-projectportals/project-portal-theme/assets/2803227/0d3095e6-c68f-452e-8935-9a2c6e0dffff">
