### PR TITLE
refactor: remove staticQuery from DevBanner layout

### DIFF
--- a/packages/gatsby-theme-project-portal/src/layouts/Layout.tsx
+++ b/packages/gatsby-theme-project-portal/src/layouts/Layout.tsx
@@ -1,32 +1,25 @@
 import React, { FunctionComponent, ReactNode } from "react"
+import { graphql } from "gatsby"
 import { Footer, BottomBanner, DevelopmentBanner, Navbar } from "../components"
-import { useProjectPortalConfig } from "../hooks"
 
 interface LayoutProps {
   path: string
   title: string
   description: string
   children: ReactNode
-  showDevBanner?: boolean
-}
-
-function getShowDevBannerSetting(showDevBanner?: boolean) {
-  // Checks whether the "showDevBanner" argument is explicitly set and use it if it is (i.e. not null),
-  // else use the showDevBannerThemeSetting.
-  const { showDevBanner: showDevBannerThemeSetting } = useProjectPortalConfig()
-  return showDevBanner ?? showDevBannerThemeSetting
+  data: { projectPortalConfig: { showDevBanner?: boolean } }
 }
 
 export const Layout: FunctionComponent<LayoutProps> = ({
   path,
-  showDevBanner,
+  data: {
+    projectPortalConfig: { showDevBanner },
+  },
   children,
 }) => {
-  const coalescedShowDevBanner = getShowDevBannerSetting(showDevBanner)
-
   return (
     <div className="w-full mx-0 bg-white border-0 xl:container xl:p-0 xl:mx-auto xl:border-l xl:border-r xl:border-gray-200 flex flex-col min-h-screen">
-      {coalescedShowDevBanner && <DevelopmentBanner />}
+      {showDevBanner && <DevelopmentBanner />}
       <Navbar activePage={path} />
       <div className="flex-1">{children}</div>
       <BottomBanner />
@@ -34,3 +27,11 @@ export const Layout: FunctionComponent<LayoutProps> = ({
     </div>
   )
 }
+
+export const query = graphql`
+  fragment LayoutData on Query {
+    projectPortalConfig {
+      showDevBanner
+    }
+  }
+`

--- a/packages/gatsby-theme-project-portal/src/pages/404.tsx
+++ b/packages/gatsby-theme-project-portal/src/pages/404.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
+import { Layout } from "../layouts"
 
 export default () => {
   return (
@@ -26,5 +27,6 @@ export { Head } from "../hooks"
 export const query = graphql`
   query {
     ...HeadData
+    ...LayoutData
   }
 `

--- a/packages/gatsby-theme-project-portal/src/pages/404.tsx
+++ b/packages/gatsby-theme-project-portal/src/pages/404.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
-import { Layout } from "../layouts"
 
 export default () => {
   return (

--- a/packages/gatsby-theme-project-portal/src/templates/about-page.js
+++ b/packages/gatsby-theme-project-portal/src/templates/about-page.js
@@ -7,6 +7,7 @@ export { Head } from "../hooks"
 export const query = graphql`
   query AboutQuery($slug: String!) {
     ...HeadData
+    ...LayoutData
     page: generalPage(slug: { eq: $slug }) {
       title
       description: lede

--- a/packages/gatsby-theme-project-portal/src/templates/card-page.js
+++ b/packages/gatsby-theme-project-portal/src/templates/card-page.js
@@ -7,6 +7,7 @@ export { Head } from "../hooks"
 export const query = graphql`
   query CardPageQuery($slug: String!, $statusFilter: [String]) {
     ...HeadData
+    ...LayoutData
     page: cardPage(slug: { eq: $slug }) {
       title
       description: lede

--- a/packages/gatsby-theme-project-portal/src/templates/contact-page.js
+++ b/packages/gatsby-theme-project-portal/src/templates/contact-page.js
@@ -7,6 +7,7 @@ export { Head } from "../hooks"
 export const query = graphql`
   query ContactQuery($slug: String!) {
     ...HeadData
+    ...LayoutData
     page: generalPage(slug: { eq: $slug }) {
       title
       description: lede

--- a/packages/gatsby-theme-project-portal/src/templates/project-detail-page.js
+++ b/packages/gatsby-theme-project-portal/src/templates/project-detail-page.js
@@ -7,6 +7,7 @@ export { Head } from "../hooks"
 export const query = graphql`
   query ProjectDetailPageQuery($slug: String!) {
     ...HeadData
+    ...LayoutData
     page: project(slug: { eq: $slug }) {
       title: question
       description: summary

--- a/packages/gatsby-theme-project-portal/src/templates/thank-you-page.js
+++ b/packages/gatsby-theme-project-portal/src/templates/thank-you-page.js
@@ -7,6 +7,7 @@ export { Head } from "../hooks"
 export const query = graphql`
   query ThankYouQuery($slug: String!) {
     ...HeadData
+    ...LayoutData
     page: generalPage(slug: { eq: $slug }) {
       title
       description: lede


### PR DESCRIPTION
Make DevBanner dependent on a single parameter passed through the page query using a new fragment `LayoutData`, (which will be extended to include data for all of the Layout-components) rather than using a static query. 