### PR TITLE
fix: warning about list items missing a key

### DIFF
--- a/packages/gatsby-theme-project-portal/src/components/Cards.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/Cards.tsx
@@ -10,7 +10,7 @@ export const Cards: FunctionComponent<CardsProps> = ({ nodes }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-3 xl:mx-6 gap-4 justify-self-center">
       {nodes.map((item, i) => (
-        <article>
+        <article key={"card_" + item.slug}>
           <Link
             to={`/project/${item.slug}`}
             state={{
@@ -18,7 +18,7 @@ export const Cards: FunctionComponent<CardsProps> = ({ nodes }) => {
               items: nodes.map((item) => `/${item.slug}`),
             }}
           >
-            <Card key={"card_" + item.slug} {...item} />
+            <Card {...item} />
           </Link>
         </article>
       ))}

--- a/packages/gatsby-theme-project-portal/src/components/Navbar.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/Navbar.tsx
@@ -58,14 +58,11 @@ export const Navbar: FunctionComponent<NavbarProps> = ({
               {pages.map(({ name, link, show }, i) =>
                 show ? (
                   <Link
+                    key={"nav" + i}
                     to={link ? link : "#"}
                     onClick={() => setNavbarOpen(false)}
                   >
-                    <NavbarItem
-                      key={"nav" + i}
-                      name={name}
-                      isActive={activePage === link}
-                    />
+                    <NavbarItem name={name} isActive={activePage === link} />
                   </Link>
                 ) : (
                   ""


### PR DESCRIPTION
The warning described here: https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key
... came up on the Card and Navbar after doing the refactoring. 