### PR TITLE
ci: add grouping for dependabot updates of gatsby and storybook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      gatsby:
+        patterns:
+          - "gatsby"
+          - "gatsby-*"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"


### PR DESCRIPTION
... using https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/