### PR TITLE
refactor: rename staticText:mainContact from staticText:main_contact_text

### DIFF
--- a/packages/gatsby-theme-project-portal/src/layouts/ProjectDetailPage.stories.tsx
+++ b/packages/gatsby-theme-project-portal/src/layouts/ProjectDetailPage.stories.tsx
@@ -22,7 +22,7 @@ export const Primary: Story = {
       projectPortalConfig: {
         projectInterestLink: "https://ccv.brown.edu",
         staticText: {
-          mainContactText: {
+          mainContact: {
             ongoingText: "ongoingText",
             completeText: "completeText",
           },

--- a/packages/gatsby-theme-project-portal/src/layouts/ProjectDetailPage.tsx
+++ b/packages/gatsby-theme-project-portal/src/layouts/ProjectDetailPage.tsx
@@ -15,7 +15,7 @@ interface ProjectDetailPageQueryResults {
     projectPortalConfig: {
       projectInterestLink: string
       staticText: {
-        mainContactText: {
+        mainContact: {
           ongoingText: string
           completeText: string
         }
@@ -35,7 +35,7 @@ export const ProjectDetailPage: FunctionComponent<
       projectPortalConfig: {
         projectInterestLink,
         staticText: {
-          mainContactText: { ongoingText, completeText },
+          mainContact: { ongoingText, completeText },
         },
       },
       defaultContactImage,

--- a/packages/gatsby-theme-project-portal/src/templates/project-detail-page.js
+++ b/packages/gatsby-theme-project-portal/src/templates/project-detail-page.js
@@ -30,7 +30,7 @@ export const query = graphql`
     projectPortalConfig {
       projectInterestLink
       staticText {
-        mainContactText {
+        mainContact {
           ongoingText
           completeText
         }

--- a/packages/gatsby-theme-project-portal/src/templates/project-detail-page.js
+++ b/packages/gatsby-theme-project-portal/src/templates/project-detail-page.js
@@ -30,7 +30,7 @@ export const query = graphql`
     projectPortalConfig {
       projectInterestLink
       staticText {
-        mainContactText: mainContactText {
+        mainContactText {
           ongoingText
           completeText
         }

--- a/packages/gatsby-theme-project-portal/src/templates/project-detail-page.js
+++ b/packages/gatsby-theme-project-portal/src/templates/project-detail-page.js
@@ -30,7 +30,7 @@ export const query = graphql`
     projectPortalConfig {
       projectInterestLink
       staticText {
-        mainContactText: main_contact_text {
+        mainContactText: mainContactText {
           ongoingText
           completeText
         }

--- a/packages/gatsby-theme-project-portal/utils/default-static-text.json
+++ b/packages/gatsby-theme-project-portal/utils/default-static-text.json
@@ -15,7 +15,7 @@
   "bottom_banner": {
     "text": "This project portal example content was developed by the The Policy Lab and the Center for Computation and Visualization at Brown University. If you have ideas for how to improve it, please let us know!"
   },
-  "mainContactText": {
+  "mainContact": {
     "ongoingText": "We plan to post results and deliverables when the project is complete. In the meantime, we welcome questions about the project.",
     "completeText": "We’re eager to learn how you use the results and welcome any questions."
   }

--- a/packages/gatsby-theme-project-portal/utils/default-static-text.json
+++ b/packages/gatsby-theme-project-portal/utils/default-static-text.json
@@ -15,7 +15,7 @@
   "bottom_banner": {
     "text": "This project portal example content was developed by the The Policy Lab and the Center for Computation and Visualization at Brown University. If you have ideas for how to improve it, please let us know!"
   },
-  "main_contact_text": {
+  "mainContactText": {
     "ongoingText": "We plan to post results and deliverables when the project is complete. In the meantime, we welcome questions about the project.",
     "completeText": "We’re eager to learn how you use the results and welcome any questions."
   }

--- a/packages/gatsby-theme-project-portal/utils/types.js
+++ b/packages/gatsby-theme-project-portal/utils/types.js
@@ -20,7 +20,7 @@ const projectPortalConfigTypeDefs = `
     contact: ContactType
     bottom_banner: BottomBannerType
     footer: FooterType
-    mainContactText: MainContactTextType
+    mainContact: MainContactType
   }
   type ContactType {
     title: String
@@ -30,7 +30,7 @@ const projectPortalConfigTypeDefs = `
     text: String
     link: String
   }
-  type MainContactTextType {
+  type MainContactType {
     ongoingText: String
     completeText: String
   }

--- a/packages/gatsby-theme-project-portal/utils/types.js
+++ b/packages/gatsby-theme-project-portal/utils/types.js
@@ -20,7 +20,7 @@ const projectPortalConfigTypeDefs = `
     contact: ContactType
     bottom_banner: BottomBannerType
     footer: FooterType
-    main_contact_text: MainContactTextType
+    mainContactText: MainContactTextType
   }
   type ContactType {
     title: String

--- a/packages/project-portal-content-netlify/utils/theme-options.js
+++ b/packages/project-portal-content-netlify/utils/theme-options.js
@@ -13,7 +13,7 @@ function loadProjectPortalThemeOptions(pluginOptions) {
     staticText: {
       footer: layoutOptions.footer,
       bottom_banner: layoutOptions.bottomBanner,
-      main_contact_text: {
+      mainContactText: {
         ongoingText: mainContactConfig.ongoingText,
         completeText: mainContactConfig.completeText,
       },

--- a/packages/project-portal-content-netlify/utils/theme-options.js
+++ b/packages/project-portal-content-netlify/utils/theme-options.js
@@ -13,7 +13,7 @@ function loadProjectPortalThemeOptions(pluginOptions) {
     staticText: {
       footer: layoutOptions.footer,
       bottom_banner: layoutOptions.bottomBanner,
-      mainContactText: {
+      mainContact: {
         ongoingText: mainContactConfig.ongoingText,
         completeText: mainContactConfig.completeText,
       },


### PR DESCRIPTION
Rename graphQL parameter: 
```graphql
staticText: { mainContact: {...}}
```

Formerly:

```graphql
staticText: { main_contact_text: {...}}
```

- Correct naming convention – lowerCamelCase rather than snake_case
- Remove redundant "text" – this is already part of the staticText name
- resolves #351 