### PR TITLE
refactor: rename bottomBanner

### DIFF
--- a/packages/gatsby-theme-project-portal/src/layouts/Layout.tsx
+++ b/packages/gatsby-theme-project-portal/src/layouts/Layout.tsx
@@ -104,7 +104,7 @@ export const query = graphql`
         show
       }
       staticText {
-        bottomBanner: bottom_banner {
+        bottomBanner {
           text
           link
         }

--- a/packages/gatsby-theme-project-portal/utils/default-static-text.json
+++ b/packages/gatsby-theme-project-portal/utils/default-static-text.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "bottom_banner": {
+  "bottomBanner": {
     "text": "This project portal example content was developed by the The Policy Lab and the Center for Computation and Visualization at Brown University. If you have ideas for how to improve it, please let us know!"
   },
   "main_contact_text": {

--- a/packages/gatsby-theme-project-portal/utils/types.js
+++ b/packages/gatsby-theme-project-portal/utils/types.js
@@ -18,7 +18,7 @@ const projectPortalConfigTypeDefs = `
   }
   type StaticTextType {
     contact: ContactType
-    bottom_banner: BottomBannerType
+    bottomBanner: BottomBannerType
     footer: FooterType
     main_contact_text: MainContactTextType
   }

--- a/packages/project-portal-content-netlify/utils/theme-options.js
+++ b/packages/project-portal-content-netlify/utils/theme-options.js
@@ -12,7 +12,7 @@ function loadProjectPortalThemeOptions(pluginOptions) {
     pages: layoutOptions.navbar.pages,
     staticText: {
       footer: layoutOptions.footer,
-      bottom_banner: layoutOptions.bottomBanner,
+      bottomBanner: layoutOptions.bottomBanner,
       main_contact_text: {
         ongoingText: mainContactConfig.ongoingText,
         completeText: mainContactConfig.completeText,


### PR DESCRIPTION
Rename graphQL parameter: 
```graphql
staticText: { bottomBanner: {...}}
```

Formerly:

```graphql
staticText: { bottom_banner: {...}}
```

- Correct naming convention – lowerCamelCase rather than snake_case
- resolves #350 
