### PR TITLE
editing the cms.js file so that media_folder points to static/image

### DIFF
--- a/packages/project-portal-content-netlify/src/cms/cms.js
+++ b/packages/project-portal-content-netlify/src/cms/cms.js
@@ -7,7 +7,7 @@ import "./cms-utils"
 // (if it exists in the site's directory static/admin/config.yml)
 CMS.init({
   config: {
-    media_folder: "content/image",
+    media_folder: "static/image",
     public_folder: "/image",
     publish_mode: "editorial_workflow",
     collections: [


### PR DESCRIPTION
This allows project pages to render images that are uploaded via netlify or stored in /static/image (see https://decapcms.org/docs/add-to-your-site/#authentication) 