### PR TITLE
ci: Create CODEOWNERS to include RENCI (and CCV) in all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+## Send PR Reviews to:
+* @thepolicylab-projectportals/renci @thepolicylab-projectportals/ccv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 ## Send PR Reviews to:
-* @thepolicylab-projectportals/renci @thepolicylab-projectportals/ccv
+* @thepolicylab-projectportals/renci


### PR DESCRIPTION
Include CODEOWNERS file to include RENCI people by default