### PR TITLE
fix: catch error and display message for parsing errors

### DIFF
--- a/packages/gatsby-theme-project-portal/src/components/SiteSearch.stories.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/SiteSearch.stories.tsx
@@ -104,7 +104,7 @@ const invalidSearches = async ({ canvasElement }) => {
 
   await userEvent.clear(searchInput)
 
-  await userEvent.type(searchInput, "____", {
+  await userEvent.type(searchInput, "--", {
     delay: 100,
   })
 }

--- a/packages/gatsby-theme-project-portal/src/components/SiteSearch.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/SiteSearch.tsx
@@ -48,7 +48,9 @@ export const SiteSearch: FunctionComponent<SearchProps> = ({
           placeholder={"Type to search pages..."}
           onChange={(e) => setSearchQuery(e.target.value)}
         />
-        <p className="px-4 text-red text-tag font-bold">{errorMessage}</p>
+        {errorMessage && (
+          <p className="px-4 text-red text-tag font-bold">{errorMessage}</p>
+        )}
         <div className="pt-2">
           Number of found pages:
           {queryResults.length}

--- a/packages/gatsby-theme-project-portal/src/components/SiteSearch.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/SiteSearch.tsx
@@ -15,17 +15,26 @@ export const SiteSearch: FunctionComponent<SearchProps> = ({
 }: SearchProps) => {
   const [searchQuery, setSearchQuery] = useState([])
   const [queryResults, setQueryResults] = useState([])
+  const [errorMessage, setErrorMessage] = useState("")
 
   useEffect(() => {
     if (searchQuery.length > 0) {
-      let searchResults = index.search(searchQuery)
-      let results = []
-      searchResults.forEach(function (result) {
-        results.push(db[result.ref])
-      })
-      setQueryResults(searchResults)
+      // catch the error, and display an error message to help user
+      try {
+        let searchResults = index.search(searchQuery)
+        setQueryResults(searchResults)
+        setErrorMessage("")
+      } catch (error) {
+        if (error instanceof lunr.QueryParseError) {
+          setErrorMessage(error.message)
+          return
+        } else {
+          throw error
+        }
+      }
     } else {
       setQueryResults([])
+      setErrorMessage("")
     }
   }, [searchQuery])
 
@@ -39,7 +48,8 @@ export const SiteSearch: FunctionComponent<SearchProps> = ({
           placeholder={"Type to search pages..."}
           onChange={(e) => setSearchQuery(e.target.value)}
         />
-        <div className=" pt-2">
+        <p className="px-4 text-red text-tag font-bold">{errorMessage}</p>
+        <div className="pt-2">
           Number of found pages:
           {queryResults.length}
         </div>


### PR DESCRIPTION
This PR provides a fix for a limitation with lunr.

[See line 3136 in lunr's query parser](https://github.com/olivernn/lunr.js/blob/master/lunr.js#L3083)

Lunr assumes characters typically used as search rules will never be text, and pushes errors when searching for them (ie "^", "-").  Because our search occurs on input and not on submit, the page would crash upon entering "^" but not pasting in "foo^10".

Fix catches these errors and displays an error message. We can choose to either use switch statement to provide a more helpful message than what lunr provides within this PR, or we can revisit it later in order to get the site search rolled out. Let me know what you all think!