### PR TITLE
test: add test for Navbar when there is a wide image and no title

### DIFF
--- a/packages/gatsby-theme-project-portal/src/components/Navbar.stories.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/Navbar.stories.tsx
@@ -13,6 +13,7 @@ export default meta
 type Story = StoryObj<typeof Navbar>
 
 export const siteTitleLogo = loadImage("image/logo-square.png", 64, 74, "fixed")
+export const ccvLogo = loadImage("image/ccv-logo.png", 143, 74, "fixed")
 
 export const Primary: Story = {
   args: {
@@ -88,6 +89,15 @@ export const EmptyStrings: Story = {
   args: {
     title: "",
     image: siteTitleLogo,
+    activePage: "",
+    pages: [],
+  },
+}
+
+export const WideImage: Story = {
+  args: {
+    title: "",
+    image: ccvLogo,
     activePage: "",
     pages: [],
   },


### PR DESCRIPTION
... test the use case which required component shadowing in the fed repo
<img width="484" alt="Screenshot 2023-12-11 at 16 45 17" src="https://github.com/thepolicylab-projectportals/project-portal-theme/assets/2803227/6f47886a-876f-4c96-93c9-03bae1c2b7fa">
