### PR TITLE
feat: add hook for useStaticQuery to grab gatsby nodes

### DIFF
--- a/packages/gatsby-theme-project-portal/src/components/SiteSearchWrapper.tsx
+++ b/packages/gatsby-theme-project-portal/src/components/SiteSearchWrapper.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent, useEffect, useState } from "react"
 import lunr from "lunr"
 import SiteSearch from "./SiteSearch"
+import { createSearchIndex } from "../../utils/search.js"
+import buildDynamicIndex from "../hooks/search"
 
 export interface SearchWrapperProps {
   siteUrl: string
@@ -9,15 +11,29 @@ export interface SearchWrapperProps {
 export const SiteSearchWrapper: FunctionComponent<SearchWrapperProps> = ({
   siteUrl,
 }: SearchWrapperProps) => {
+  const { allProject, allGeneralPage } = buildDynamicIndex()
   const [idx, setIdx] = useState()
   const [db, setDb] = useState()
   useEffect(() => {
     const getIndex = async () => {
       const savedIndex = await (await fetch("/lunr-index.json")).json()
       const db = await (await fetch("/documents-reduced.json")).json()
-
-      setIdx(lunr.Index.load(savedIndex))
-      setDb(db)
+      try {
+        setIdx(lunr.Index.load(savedIndex))
+        setDb(db)
+      } catch {
+        const [index, documents] = createSearchIndex({
+          allProject,
+          allGeneralPage,
+        })
+        setIdx(index)
+        setDb(
+          documents.reduce(function (page, document) {
+            page[document.slug] = document
+            return page
+          }, {})
+        )
+      }
     }
 
     // Because Gatsby runs this on build, we need to say to ignore getting the json files

--- a/packages/gatsby-theme-project-portal/src/hooks/search.tsx
+++ b/packages/gatsby-theme-project-portal/src/hooks/search.tsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+export default function buildDynamicIndex() {
+  const { allProject, allGeneralPage } = useStaticQuery(graphql`
+    query {
+      allProject {
+        nodes {
+          title
+          agency
+          topics {
+            title
+          }
+          slug
+          summary
+          statusOfData
+          status
+          startDate
+          requirement
+          question
+          purpose
+          projectTeam {
+            name
+            employer
+          }
+          priorResearch
+          opportunityCloses
+          mainContact {
+            name
+          }
+          fundingInfo
+          expertise
+          faq {
+            text
+            title
+          }
+          deliverable
+          emailContent
+          endDate
+          slug
+        }
+      }
+      allGeneralPage {
+        nodes {
+          slug
+          lede
+          faq {
+            text
+            title
+          }
+          aims {
+            text
+            title
+          }
+          title
+        }
+      }
+    }
+  `)
+  return { allProject, allGeneralPage }
+}

--- a/packages/gatsby-theme-project-portal/src/hooks/search.tsx
+++ b/packages/gatsby-theme-project-portal/src/hooks/search.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 export default function buildDynamicIndex() {
+  // this query is duplicated in packages/gatsby-theme-project-portal/utils/search.js
   const { allProject, allGeneralPage } = useStaticQuery(graphql`
     query {
       allProject {

--- a/packages/gatsby-theme-project-portal/utils/search.js
+++ b/packages/gatsby-theme-project-portal/utils/search.js
@@ -182,7 +182,7 @@ function createSearchIndex(searchNodes) {
   })
   return [index, documents]
 }
-
+// This query is duplicated in the search hook! (packages/gatsby-theme-project-portal/src/hooks/search.tsx)
 const searchQuery = `
     query {
       allProject {


### PR DESCRIPTION
Most important piece in the SiteSearchWrapper

```
try {
        setIdx(lunr.Index.load(savedIndex))
        setDb(db)
      } catch {
        const [index, documents] = createSearchIndex({
          allProject,
          allGeneralPage,
        })
        setIdx(index)
        setDb(
          documents.reduce(function (page, document) {
            page[document.slug] = document
            return page
          }, {})
        )
      }
```

- resolves #730 